### PR TITLE
modalを表示できなくなることがある不具合修正.

### DIFF
--- a/templates/_script.html.erb
+++ b/templates/_script.html.erb
@@ -166,6 +166,11 @@
       getList() {
         this.request('GET', '/list', null, (res) => {
           this.Containers = res[0].data
+
+          // 要素が描画された後にModalを再度認識させる
+          setTimeout(() => {
+            $('.modal').modal();
+          }, 200)
         })
       },
       postRestart(subdomain) {


### PR DESCRIPTION
## Issue 

#1

## 原因

```js
  $(document).ready(function(){
    $('.modal').modal()
  })
```

によってmodalを認識させる処理に
List APIを叩いて描画する処理が追いついていない場合発生する
(`$('.modal').modal()` する時にまだmodalが描画できていない)

## 修正内容

List API を叩き終わった 200ms 後に再度 `$('.modal').modal()` を呼び出すことによって
追加描画されたmodalが認識され、解消した